### PR TITLE
お気に入り曲のDBインサートと曲評価の入力の実装

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -3,26 +3,11 @@ import Link from 'next/link';
 const Dashboard = () => {
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold text-center mb-8">Dashboard</h1>
+      <h1 className="text-3xl font-bold text-center mb-8">曲の分類</h1>
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         <li className="bg-gray-800 text-white rounded-lg shadow-lg p-4 text-center">
           <Link href="/library" className="text-lg font-semibold hover:underline">
-            お気に入りの曲
-          </Link>
-        </li>
-        <li className="bg-gray-800 text-white rounded-lg shadow-lg p-4 text-center">
-          <Link href="/top-tracks" className="text-lg font-semibold hover:underline">
-            最近特に再生されている曲
-          </Link>
-        </li>
-        <li className="bg-gray-800 text-white rounded-lg shadow-lg p-4 text-center">
-          <Link href="/recently-tracks" className="text-lg font-semibold hover:underline">
-            直近で再生された曲 - 50件
-          </Link>
-        </li>
-        <li className="bg-gray-800 text-white rounded-lg shadow-lg p-4 text-center">
-          <Link href="/playlist" className="text-lg font-semibold hover:underline">
-            その他のマイプレイリスト
+            ここをクリック
           </Link>
         </li>
       </ul>

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,0 +1,41 @@
+// 例: src/lib/spotify.ts などに置く
+
+import axios from 'axios';
+
+type SpotifyTrack = {
+  id: string;
+  name: string;
+  artists: { name: string }[];
+  album: { name: string; images: { url: string }[] };
+  // 必要に応じてフィールド追加
+};
+
+type LibraryTracksResponse = {
+  items: { track: SpotifyTrack }[];
+  total: number;
+};
+
+export async function fetchSpotifySavedTracks(accessToken: string) {
+  const allTracks: SpotifyTrack[] = [];
+  let offset = 0;
+  const limit = 50; // Spotify APIでは一度に取得できる上限
+  let total = 0;
+
+  do {
+    const response = await axios.get<LibraryTracksResponse>(
+      'https://api.spotify.com/v1/me/tracks',
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        params: { limit, offset },
+      }
+    );
+    const data = response.data;
+
+    // data.items は { track: SpotifyTrack }[] の配列
+    allTracks.push(...data.items.map((item) => item.track));
+    total = data.total;
+    offset += limit;
+  } while (offset < total);
+
+  return allTracks;
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,33 @@
+// 例: src/lib/supabase.ts などに置く
+import { supabase } from '@/utils/supabaseClient';
+
+type TrackToSave = {
+  spotify_track_id: string;
+  user_id: string;  // このトラックを取得したユーザーのID
+  name: string;
+  artist_name: string;
+  album_name: string;
+  image_url?: string;
+};
+
+export async function saveTracksToSupabase(
+  tracks: TrackToSave[]
+): Promise<void> {
+  if (tracks.length === 0) return;
+
+  // 大量のレコードを都度1件ずつ upsert するとパフォーマンスが低下する可能性があるため、
+  // まとめて upsert する方法を推奨。
+  // Supabase の from(...).upsert([...]) で配列を一括 upsert できます。
+  const { data, error } = await supabase
+    .from('tracks')
+    .upsert(tracks, {
+      onConflict: 'spotify_track_id',
+    });
+
+  if (error) {
+    console.error('Error saving tracks to Supabase:', error);
+    throw error;
+  }
+
+  console.log('Tracks saved to Supabase:', data);
+}

--- a/src/pages/api/tracks.ts
+++ b/src/pages/api/tracks.ts
@@ -1,0 +1,46 @@
+// pages/api/tracks.ts
+import { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/utils/supabaseClient';  // あなたのSupabaseクライアントへのパス
+
+// 受け取るデータの型
+type TrackUpdateData = {
+  spotify_track_id: string;
+  user_id: string;           // ログイン中のユーザーID（spotify_user_id） 
+  song_favorite_level?: number | null;
+  can_singing?: boolean | null;
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'PUT') {
+    try {
+      // PUTリクエストで渡されるであろう JSON ボディをパース
+      const { trackUpdates } = req.body as { trackUpdates: TrackUpdateData[] };
+
+      // trackUpdatesは配列で受け取る想定
+      if (!Array.isArray(trackUpdates)) {
+        return res.status(400).json({ error: 'Invalid request body' });
+      }
+
+      // Supabaseの upsert で一括保存
+      const { data, error } = await supabase
+        .from('tracks')
+        .upsert(trackUpdates, {
+          onConflict: 'spotify_track_id',
+        });
+
+      if (error) {
+        console.error('[tracks API] upsert error:', error);
+        return res.status(500).json({ error: error.message });
+      }
+
+      return res.status(200).json({ data });
+    } catch (err) {
+      console.error('[tracks API] error:', err);
+      return res.status(500).json({ error: 'Server error' });
+    }
+  }
+
+  // それ以外のメソッドは 405 を返す
+  res.setHeader('Allow', ['PUT']);
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 // pages/index.tsx
 
-import Dashboard from '@/components/dashboard';
 import { useSession, signIn, signOut } from 'next-auth/react';
 import Image from 'next/image';
+import Link from 'next/link';
 
 export default function Home() {
   const { data: session } = useSession();
@@ -16,58 +16,73 @@ export default function Home() {
   };
 
   return (
-    <div className="relative flex flex-col items-center justify-center min-h-screen bg-gray-900 text-white">
-      {/* ユーザーアイコンを右上に表示するためのコンテナ */}
-      {session && (
-        <div className="absolute top-4 right-4 flex items-center space-x-2">
-          {/* ユーザーアイコン */}
-          {session.user?.image && (
-            <Image
-              src={session.user.image}
-              alt="Profile"
-              width={50}
-              height={50}
-              className="w-10 h-10 rounded-full"
-            />
-          )}
-          {/* ログアウトボタンをアイコン付近に置く場合 */}
-          <button
-            onClick={handleLogout}
-            className="px-3 py-1 bg-red-500 hover:bg-red-600 rounded-md text-sm"
-          >
-            Logout
-          </button>
-        </div>
-      )}
+    <div className="relative flex flex-col min-h-screen bg-gray-900 text-white">
+      {/* ヘッダー: タイトルやログアウトボタンをまとめる */}
+      <header className="flex items-center justify-between p-4 bg-gray-800">
+        <h1 className="text-xl font-bold">
+          Spotify History App
+        </h1>
+        {session && (
+          <div className="flex items-center space-x-4">
+            {/* ユーザーアイコン */}
+            {session.user?.image && (
+              <Image
+                src={session.user.image}
+                alt="Profile"
+                width={40}
+                height={40}
+                className="w-10 h-10 rounded-full"
+              />
+            )}
+            {/* ログアウトボタン */}
+            <button
+              onClick={handleLogout}
+              className="px-3 py-1 bg-red-500 hover:bg-red-600 rounded-md text-sm"
+            >
+              Logout
+            </button>
+          </div>
+        )}
+      </header>
 
-      {!session ? (
-        <div className="text-center">
-          <h1 className="text-4xl font-bold mb-6">
-            Welcome to Spotify History App
-          </h1>
-          <p className="text-lg text-gray-400 mb-8">
-            Discover your listening history and favorite tracks.
-          </p>
-          <button
-            onClick={handleLogin}
-            className="px-6 py-3 bg-green-500 hover:bg-green-600 text-white text-lg font-semibold rounded-lg shadow-md transition-all"
-          >
-            Login with Spotify
-          </button>
-        </div>
-      ) : (
-        <div className="text-center mt-10">
-          <h1 className="text-4xl font-bold mb-6">
-            Hello, {session.user?.name || 'User'}!
-          </h1>
-          <p className="text-lg text-gray-400 mb-8">
-            You are logged in. Let&apos;s explore your Spotify history!
-          </p>
-          <Dashboard />
-        </div>
-      )}
+      {/* メインコンテンツ */}
+      <main className="flex-1 flex flex-col items-center justify-center p-4">
+        {!session ? (
+          // ===== ログイン前 =====
+          <div className="text-center">
+            <h2 className="text-4xl font-bold mb-6">
+              Welcome to Spotify History App
+            </h2>
+            <p className="text-lg text-gray-400 mb-8">
+              Discover your listening history and favorite tracks.
+            </p>
+            <button
+              onClick={handleLogin}
+              className="px-6 py-3 bg-green-500 hover:bg-green-600 text-white text-lg font-semibold rounded-lg shadow-md transition-all"
+            >
+              Login with Spotify
+            </button>
+          </div>
+        ) : (
+          // ===== ログイン後 =====
+          <div className="container mx-auto px-4 py-8 flex-1">
+            <h1 className="text-3xl font-bold text-center mb-8">曲の分類</h1>
+            <p className="text-gray-400 text-center mb-8">
+              ここではあなたの楽曲を「お気に入り度」と「歌えるかどうか」で分類します。
+            </p>
+            <ul className="flex justify-center sm:grid-cols-2 md:grid-cols-3 gap-6">
+              <li className="bg-gray-800 text-white rounded-lg shadow-lg p-6 text-center hover:bg-gray-700 transition-colors">
+                <Link href="/library" className="text-lg font-semibold hover:underline">
+                  ライブラリへ
+                </Link>
+              </li>
+            </ul>
+          </div>
+        )}
+      </main>
 
-      <footer className="mt-10 text-gray-600 text-sm">
+      {/* フッター */}
+      <footer className="p-4 bg-gray-800 text-center text-sm text-gray-400">
         © {new Date().getFullYear()} Spotify History App. All rights reserved.
       </footer>
     </div>

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -1,77 +1,346 @@
-// src/components/Library.tsx (or pages/library.tsx)
-
+// pages/tracks/index.tsx
+import React, { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react'; // next-auth使用例
+import { supabase } from '@/utils/supabaseClient';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
 
-const Library = () => {
-  const [tracks, setTracks] = useState<Track[]>([]);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchLibrary = async () => {
-      try {
-        // credentials: 'include' はクッキー送信を有効化
-        // NextAuthのセッションクッキーが送られる
-        const response = await fetch('/api/library', {
-          credentials: 'include',
-        });
-        if (!response.ok) {
-          throw new Error('Failed to fetch library');
-        }
-        const data = await response.json();
-        setTracks(data.items);
-      } catch (err) {
-        if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError('Unknown error occurred');
-        }
-      }
-    };
-
-    fetchLibrary();
-  }, []);
-
-  if (error) {
-    return <div className="text-red-500 text-center mt-10">Error: {error}</div>;
-  }
-
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold text-center mb-4">
-        Your Spotify Library
-      </h1>
-      <p className="text-center text-gray-500 mb-8">
-        Total Tracks: <span className="font-semibold">{tracks.length}</span>
-      </p>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-        {tracks.map((track) => (
-          <li
-            key={track.id}
-            className="bg-gray-800 text-white rounded-lg shadow-lg overflow-hidden"
-          >
-            <div className="relative w-full h-48">
-              <Image
-                src={track.album.images[0]?.url || '/placeholder.png'}
-                alt={track.album.name}
-                layout="fill"
-                objectFit="cover"
-              />
-            </div>
-            <div className="p-4">
-              <h2 className="text-lg font-semibold truncate">{track.name}</h2>
-              <p className="text-sm text-gray-400">
-                {track.artists.map((artist) => artist.name).join(', ')}
-              </p>
-              <p className="text-sm text-gray-500 italic truncate">
-                {track.album.name}
-              </p>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+type TrackData = {
+  spotify_track_id: string;
+  image_url?: string;
+  name: string;
+  artist_name?: string;
+  album_name?: string;
+  user_id: string; // DBでの参照外部キー
+  song_favorite_level?: number | null;
+  // can_singing は integer (0|1) or null を想定
+  can_singing?: number | null;  
 };
 
-export default Library;
+export default function TrackClassificationPage() {
+  const { data: session } = useSession();
+  const userId = session?.user?.id; // 例: session.user.id に spotify_user_idが入っていると仮定
+
+  // 取得した楽曲データ
+  const [tracks, setTracks] = useState<TrackData[]>([]);
+  // ローカルで変更したデータを覚えておく
+  const [updatedTracks, setUpdatedTracks] = useState<Map<string, TrackData>>(new Map());
+
+  // DBからユーザーの楽曲一覧を取得
+  useEffect(() => {
+    if (!userId) return;
+
+    const fetchTracks = async () => {
+      const { data, error } = await supabase
+        .from('tracks')
+        .select('*')
+        .eq('user_id', userId);
+
+      if (error) {
+        console.error('Error fetching tracks:', error);
+        return;
+      }
+      if (data) {
+        setTracks(data as TrackData[]);
+      }
+    };
+    fetchTracks();
+  }, [userId]);
+
+  // ==========================
+  // お気に入り度 (1〜5) セレクト
+  // ==========================
+  const handleSongFavoriteLevelChange = (trackId: string, level: number) => {
+    setUpdatedTracks((prev) => {
+      const newMap = new Map(prev);
+      const original = newMap.get(trackId) || tracks.find((t) => t.spotify_track_id === trackId);
+      if (!original) return newMap;
+      newMap.set(trackId, { ...original, song_favorite_level: level });
+      return newMap;
+    });
+  };
+
+  // ==========================
+  // 歌えるか (0|1|null) セレクト
+  // ==========================
+  const handleCanSingingChange = (trackId: string, value: string) => {
+    // value は '0'|'1'|'' (未選択)
+    let newValue: number | null;
+    if (value === '1') {
+      newValue = 1;   // 歌える
+    } else if (value === '0') {
+      newValue = 0;   // 歌えない
+    } else {
+      newValue = null; // 未選択
+    }
+
+    setUpdatedTracks((prev) => {
+      const newMap = new Map(prev);
+      const original = newMap.get(trackId) || tracks.find((t) => t.spotify_track_id === trackId);
+      if (!original) return newMap;
+      newMap.set(trackId, { ...original, can_singing: newValue });
+      return newMap;
+    });
+  };
+
+  // ==========================
+  // 入力済み件数と分類完了曲
+  // ==========================
+  // 「song_favorite_level」と「can_singing」が両方とも null でなければ入力済みとみなす
+  const updatedCount = Array.from(updatedTracks.values()).filter(
+    (t) => t.song_favorite_level != null && t.can_singing != null
+  ).length;
+
+  // DB 上で既に song_favorite_level, can_singing が設定済みの曲
+  const completedTracks = tracks.filter(
+    (t) => t.song_favorite_level != null && t.can_singing != null
+  );
+
+  // ==========================
+  // 保存ボタン (Upsert)
+  // ==========================
+  const handleSave = async () => {
+    if (updatedTracks.size === 0) return;
+
+    const trackUpdates = Array.from(updatedTracks.values()).map((t) => ({
+      spotify_track_id: t.spotify_track_id,
+      user_id: t.user_id,
+      song_favorite_level: t.song_favorite_level,
+      can_singing: t.can_singing,
+    }));
+
+    try {
+      const res = await fetch('/api/tracks', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ trackUpdates }),
+      });
+      if (!res.ok) {
+        console.error('Failed to upsert tracks', await res.text());
+        return;
+      }
+
+      // 成功時は updatedTracks をクリア → DB再取得
+      setUpdatedTracks(new Map());
+      const { data, error } = await supabase
+        .from('tracks')
+        .select('*')
+        .eq('user_id', userId);
+      if (error) {
+        console.error('Error refetching tracks after save:', error);
+      } else if (data) {
+        setTracks(data as TrackData[]);
+      }
+    } catch (err) {
+      console.error('Save error:', err);
+    }
+  };
+
+  // ==========================
+  // レスポンシブUI
+  // ==========================
+  return (
+    <div className="flex flex-col min-h-screen">
+      {/* ヘッダー */}
+      <header className="p-4 bg-gray-800 text-white text-center">
+        <h1 className="text-2xl font-bold">曲の分類</h1>
+      </header>
+
+      {/* メインコンテンツ */}
+      <main className="flex-1 p-4">
+        {/* コールアウト枠（説明） */}
+        <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-md">
+          <p>
+            このページでは、以下のように曲の分類ができます。<br />
+            - お気に入り度（song_favorite_level）は1〜5段階<br />
+            - 歌えるか歌えないか（can_singing）は 0/1 または未選択
+          </p>
+        </div>
+
+        {/* ========== Mobile向けUI ========== */}
+        <div className="block md:hidden">
+          <h2 className="text-xl font-semibold mb-2">曲一覧 (Mobile Layout)</h2>
+          {tracks.map((track) => {
+            const updateObj = updatedTracks.get(track.spotify_track_id);
+            const favoriteValue = updateObj?.song_favorite_level ?? track.song_favorite_level ?? '';
+
+            // can_singing = 1->'1', 0->'0', null->''
+            const singingState = updateObj?.can_singing ?? track.can_singing;
+            const singingValue =
+              singingState === 1 ? '1'
+              : singingState === 0 ? '0'
+              : '';
+
+            return (
+              <div key={track.spotify_track_id} className="mb-4 border-b pb-2">
+                <div className="flex gap-2">
+                  {track.image_url && (
+                    <Image
+                      src={track.image_url || '/placeholder.png'}
+                      alt={track.name || 'No Album'}
+                      width={64}
+                      height={64}
+                      className="object-cover"
+                    />
+                  )}
+                  <div>
+                    <div className="font-bold">{track.name}</div>
+                    <div className="text-sm text-gray-600">{track.artist_name}</div>
+                  </div>
+                </div>
+                <div className="mt-2 flex gap-2">
+                  {/* お気に入り度 */}
+                  <select
+                    value={favoriteValue}
+                    onChange={(e) => handleSongFavoriteLevelChange(
+                      track.spotify_track_id,
+                      Number(e.target.value)
+                    )}
+                    className="border rounded p-1"
+                  >
+                    <option value="">曲の好き度</option>
+                    {[1,2,3,4,5].map((num) => (
+                      <option key={num} value={num}>{num}</option>
+                    ))}
+                  </select>
+
+                  {/* can_singing (0 or 1 or null) */}
+                  <select
+                    value={singingValue}
+                    onChange={(e) => handleCanSingingChange(
+                      track.spotify_track_id,
+                      e.target.value
+                    )}
+                    className="border rounded p-1"
+                  >
+                    <option value="">歌えるかどうか</option>
+                    <option value="1">歌える</option>
+                    <option value="0">歌えない</option>
+                  </select>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* ========== PC向けUI ========== */}
+        <div className="hidden md:block">
+          <h2 className="text-xl font-semibold mb-2">曲一覧 (PC Layout)</h2>
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="bg-gray-200">
+                <th className="p-2 border">画像</th>
+                <th className="p-2 border">曲名</th>
+                <th className="p-2 border">アーティスト</th>
+                <th className="p-2 border">お気に入り度</th>
+                <th className="p-2 border">歌える？</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tracks.map((track) => {
+                const updateObj = updatedTracks.get(track.spotify_track_id);
+                const favoriteValue = updateObj?.song_favorite_level ?? track.song_favorite_level ?? '';
+
+                const singingState = updateObj?.can_singing ?? track.can_singing;
+                const singingValue =
+                  singingState === 1 ? '1'
+                  : singingState === 0 ? '0'
+                  : '';
+
+                return (
+                  <tr key={track.spotify_track_id} className="border-b">
+                    <td className="p-2 border text-center">
+                      {track.image_url && (
+                        <Image
+                          src={track.image_url || '/placeholder.png'}
+                          alt={track.name || 'No Album'}
+                          width={64}
+                          height={64}
+                          className="object-cover mx-auto"
+                        />
+                      )}
+                    </td>
+                    <td className="p-2 border">{track.name}</td>
+                    <td className="p-2 border">{track.artist_name}</td>
+                    <td className="p-2 border">
+                      <select
+                        value={favoriteValue}
+                        onChange={(e) => handleSongFavoriteLevelChange(
+                          track.spotify_track_id,
+                          Number(e.target.value)
+                        )}
+                        className="border rounded p-1"
+                      >
+                        <option value="">未選択</option>
+                        {[1,2,3,4,5].map((num) => (
+                          <option key={num} value={num}>{num}</option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="p-2 border">
+                      <select
+                        value={singingValue}
+                        onChange={(e) => handleCanSingingChange(
+                          track.spotify_track_id,
+                          e.target.value
+                        )}
+                        className="border rounded p-1"
+                      >
+                        <option value="">未選択</option>
+                        <option value="1">歌える</option>
+                        <option value="0">歌えない</option>
+                      </select>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* 分類完了曲の表示 */}
+        <div className="mt-6">
+          <h3 className="text-lg font-semibold">分類完了曲</h3>
+          <p>入力が完了している楽曲: {completedTracks.length} 曲</p>
+          <div className="mt-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {completedTracks.map((track) => (
+              <div key={track.spotify_track_id} className="border p-2 rounded">
+                {track.image_url && (
+                  <Image
+                    src={track.image_url || '/placeholder.png'}
+                    alt={track.name || 'No Album'}
+                    width={200}
+                    height={200}
+                    className="object-cover"
+                  />
+                )}
+                <div className="mt-2">
+                  <div className="font-bold">{track.name}</div>
+                  <div>{track.artist_name}</div>
+                  <div>
+                    お気に入り度: {track.song_favorite_level}
+                    <br />
+                    歌える?: 
+                    {track.can_singing === 1 ? '歌える' 
+                     : track.can_singing === 0 ? '歌えない' 
+                     : '未選択'}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </main>
+
+      {/* フッター (画面下部固定) */}
+      <footer className="p-4 border-t bg-white text-center sticky bottom-0">
+        <p className="mb-2">現在 {updatedCount} 曲入力されています</p>
+        <button
+          onClick={handleSave}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        >
+          保存
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -17,5 +17,12 @@ declare module 'next-auth' {
   interface Session {
     accessToken?: string;
     error?: string;
+    user?: {
+      id?: string | null;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      // 必要に応じて他のフィールド
+    };
   }
 }

--- a/src/types/spotify.d.ts
+++ b/src/types/spotify.d.ts
@@ -12,6 +12,7 @@ interface Playlist {
   name: string;
   images: Array<{ url: string }>;
   owner: {
+    id: string,
     display_name: string;
   };
   tracks: {


### PR DESCRIPTION
# Samary

- ログイン後のUI変更とレスポンシブ対応の実装
- ログイン時にユーザー情報とお気に入り曲のライブラリ情報の取得、データベースへの入力
この部分に関して「ユーザーに曲評価してもらった後に再度ライブラリを取得してデータベースに入力した時、曲評価がリセットされるのではないか」という疑念点があったが、こちらは曲評価されたデータはリセットされないようになっていることを確認済み
- 曲評価の分類のミニマム実装

# 動作確認用の動画
こちらはSlackにお送りしたため、ご確認ください。