### PR TITLE
楽曲の再生機能の追加

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,18 @@ const nextConfig: NextConfig = {
 
 module.exports = {
   images: {
-    domains: ['mosaic.scdn.co', 'i.scdn.co'], // Spotifyの画像ホストを追加
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'i.scdn.co',
+        pathname: '/image/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'mosaic.scdn.co',
+        pathname: '/image/**',
+      },
+    ],
   },
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,6 +32,10 @@ export default function Home() {
                 width={40}
                 height={40}
                 className="w-10 h-10 rounded-full"
+                onError={(e) => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = '/fallback.png';
+                }}
               />
             )}
             {/* ログアウトボタン */}


### PR DESCRIPTION
# Summary

- ログインしてアクセストークンを取得した状態にしておく
- DBの`user`テーブルからユーザーのIDと名前を参照して、選択する
- 選択されたユーザーのIDと`tracks`テーブルのユーザーIDを参照して選択ユーザーのお気に入り曲を取得する
- 取得された楽曲をiframeで作成したプレイヤーで再生する

※ サビだけを再生することはSDKを使用してできると思うのですが、楽曲一つ一つにサビの始まりと終わりのmsを入力する必要があり、現実的でない気がしています。

---
↓ Minimalist30でログインして僕の楽曲データを再生している様子
![スクリーンショット 2025-01-10 124334](https://github.com/user-attachments/assets/beb0da46-b512-4b77-bd0c-a5605366639b)
