### PR TITLE
分類のUI修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^6.3.1",
         "@mui/material": "^6.3.1",
         "@supabase/supabase-js": "^2.47.10",
         "axios": "^1.7.9",
@@ -976,6 +977,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.3.1.tgz",
+      "integrity": "sha512-nJmWj1PBlwS3t1PnoqcixIsftE+7xrW3Su7f0yrjPw4tVjYrgkhU0hrRp+OlURfZ3ptdSkoBkalee9Bhf1Erfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.3.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^6.3.1",
     "@mui/material": "^6.3.1",
     "@supabase/supabase-js": "^2.47.10",
     "axios": "^1.7.9",

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -4,37 +4,61 @@ import { useSession } from 'next-auth/react';
 import { supabase } from '@/utils/supabaseClient';
 import Image from 'next/image';
 
-// ★ Material UI コンポーネントをインポート
+// MUI
 import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Container,
+  Box,
+  Button,
   FormControl,
+  FormControlLabel,
   FormLabel,
   RadioGroup,
   Radio,
-  FormControlLabel,
-  Checkbox
+  Checkbox,
+  Alert,
+  Tabs,
+  Tab,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableBody,
+  TableCell,
+  Paper,
+  Card,
+  CardMedia,
+  CardContent,
 } from '@mui/material';
+
+import CloseIcon from '@mui/icons-material/Close';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 
 type TrackData = {
   spotify_track_id: string;
-  image_url?: string;
+  user_id: string;
   name: string;
   artist_name?: string;
   album_name?: string;
-  user_id: string; // DBでの参照外部キー
-  song_favorite_level?: number | null; // 0~5あたり?
-  can_singing?: number | null;         // 0 or 1 or null
+  image_url?: string;
+  can_singing?: number | null;         // DB: can_singing = 0~4, null
+  song_favorite_level?: number | null; // DB: song_favorite_level = 1~4, null
 };
 
 export default function TrackClassificationPage() {
   const { data: session } = useSession();
   const userId = session?.user?.id;
 
-  // 楽曲データ
+  // 全楽曲
   const [tracks, setTracks] = useState<TrackData[]>([]);
-  // ローカルの変更データ
+  // ローカル変更を記録
   const [updatedTracks, setUpdatedTracks] = useState<Map<string, TrackData>>(new Map());
 
+  // ==========================
   // DBからユーザーの楽曲一覧を取得
+  // ==========================
   useEffect(() => {
     if (!userId) return;
 
@@ -56,43 +80,55 @@ export default function TrackClassificationPage() {
   }, [userId]);
 
   // ==========================
-  // お気に入り度: ラジオボタン(MUI)
+  // 思い入れ (song_favorite_level: 1~4, null)
   // ==========================
-  // level: number or null
-  const handleSongFavoriteLevelChange = (trackId: string, level: number | null) => {
+  const handleFavoriteLevelChange = (trackId: string, level: number | null) => {
     setUpdatedTracks((prev) => {
       const newMap = new Map(prev);
-      const original = newMap.get(trackId) || tracks.find((t) => t.spotify_track_id === trackId);
-      if (!original) return newMap;
-      newMap.set(trackId, { ...original, song_favorite_level: level });
+      const base = newMap.get(trackId) || tracks.find((t) => t.spotify_track_id === trackId);
+      if (!base) return newMap;
+      newMap.set(trackId, { ...base, song_favorite_level: level });
       return newMap;
     });
   };
 
   // ==========================
-  // 歌えるかどうか: チェックボックス(MUI)
+  // 歌えないチェック => can_singing=0
   // ==========================
-  // checked => true => can_singing=1, false => can_singing=0
-  const handleCanSingingChange = (trackId: string, checked: boolean) => {
+  const handleCannotSingCheck = (trackId: string, checked: boolean) => {
     setUpdatedTracks((prev) => {
       const newMap = new Map(prev);
-      const original = newMap.get(trackId) || tracks.find((t) => t.spotify_track_id === trackId);
-      if (!original) return newMap;
-      newMap.set(trackId, { ...original, can_singing: checked ? 1 : 0 });
+      const base = newMap.get(trackId) || tracks.find((t) => t.spotify_track_id === trackId);
+      if (!base) return newMap;
+
+      const newVal = checked ? 0 : null; // 0 => 歌えない, null => 未選択
+      newMap.set(trackId, { ...base, can_singing: newVal });
       return newMap;
     });
   };
 
   // ==========================
-  // 入力済み件数と分類完了曲
+  // 歌いやすさ (1~4, null)
+  // ==========================
+  const handleCanSingingChange = (trackId: string, level: number | null) => {
+    setUpdatedTracks((prev) => {
+      const newMap = new Map(prev);
+      const base = newMap.get(trackId) || tracks.find((t) => t.spotify_track_id === trackId);
+      if (!base) return newMap;
+      newMap.set(trackId, { ...base, can_singing: level });
+      return newMap;
+    });
+  };
+
+  // ==========================
+  // 分類完了判断
   // ==========================
   const updatedCount = Array.from(updatedTracks.values()).filter(
-    (t) => t.song_favorite_level != null && t.can_singing != null
+    (t) => t.can_singing != null && t.song_favorite_level != null
   ).length;
 
-  // DB 上で既に song_favorite_level, can_singing が設定済みの曲
   const completedTracks = tracks.filter(
-    (t) => t.song_favorite_level != null && t.can_singing != null
+    (t) => t.can_singing != null && t.song_favorite_level != null
   );
 
   // ==========================
@@ -104,8 +140,8 @@ export default function TrackClassificationPage() {
     const trackUpdates = Array.from(updatedTracks.values()).map((t) => ({
       spotify_track_id: t.spotify_track_id,
       user_id: t.user_id,
-      song_favorite_level: t.song_favorite_level,
       can_singing: t.can_singing,
+      song_favorite_level: t.song_favorite_level
     }));
 
     try {
@@ -119,176 +155,187 @@ export default function TrackClassificationPage() {
         return;
       }
 
-      // 更新成功 -> updatedTracksクリア -> DB再取得
+      // 成功時 => updatedTracksクリア & DB再取得
       setUpdatedTracks(new Map());
       const { data, error } = await supabase
         .from('tracks')
         .select('*')
         .eq('user_id', userId);
-      if (error) {
-        console.error('Error refetching tracks after save:', error);
-      } else if (data) {
-        setTracks(data as TrackData[]);
-      }
+      if (error) console.error('Error refetching tracks:', error);
+      else if (data) setTracks(data as TrackData[]);
     } catch (err) {
       console.error('Save error:', err);
     }
   };
 
+  // ==========================
+  // モバイル用のタブ切り替え
+  // ==========================
+  const [mobileTab, setMobileTab] = useState(0);
+  const handleChangeMobileTab = (event: React.SyntheticEvent, newValue: number) => {
+    setMobileTab(newValue);
+  };
+  // 未分類の曲
+  const unclassifiedTracks = tracks.filter(
+    (t) => t.can_singing == null || t.song_favorite_level == null
+  );
+
+  // ==========================
+  // 再分類 (PC / Mobile 共通)
+  // ==========================
+  const [editingTrackId, setEditingTrackId] = useState<string | null>(null);
+  const [tempCanSinging, setTempCanSinging] = useState<number | null>(null);
+  const [tempFavoriteLevel, setTempFavoriteLevel] = useState<number | null>(null);
+
+  const startReclassify = (track: TrackData) => {
+    setEditingTrackId(track.spotify_track_id);
+    setTempCanSinging(track.can_singing ?? null);
+    setTempFavoriteLevel(track.song_favorite_level ?? null);
+  };
+
+  const cancelReclassify = () => {
+    setEditingTrackId(null);
+    setTempCanSinging(null);
+    setTempFavoriteLevel(null);
+  };
+
+  const saveReclassify = async () => {
+    if (!editingTrackId) return;
+
+    const singleUpdate = {
+      spotify_track_id: editingTrackId,
+      user_id: userId,
+      can_singing: tempCanSinging,
+      song_favorite_level: tempFavoriteLevel
+    };
+    try {
+      const res = await fetch('/api/tracks', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ trackUpdates: [singleUpdate] }),
+      });
+      if (!res.ok) {
+        console.error('Failed to upsert track', await res.text());
+      } else {
+        const { data, error } = await supabase
+          .from('tracks')
+          .select('*')
+          .eq('user_id', userId);
+        if (!error && data) {
+          setTracks(data as TrackData[]);
+        }
+      }
+
+      setUpdatedTracks((prev) => {
+        const newMap = new Map(prev);
+        newMap.delete(editingTrackId);
+        return newMap;
+      });
+    } catch (err) {
+      console.error('Save error:', err);
+    }
+    setEditingTrackId(null);
+    setTempCanSinging(null);
+    setTempFavoriteLevel(null);
+  };
+
+  const isEditing = (trackId: string) => editingTrackId === trackId;
+
   return (
-    <div className="flex flex-col min-h-screen">
+    <Box display="flex" flexDirection="column" minHeight="100vh">
       {/* ヘッダー */}
-      <header className="p-4 bg-gray-800 text-white text-center">
-        <h1 className="text-2xl font-bold">曲の分類 (MUI)</h1>
-      </header>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            曲の分類
+          </Typography>
+        </Toolbar>
+      </AppBar>
 
-      {/* メインコンテンツ */}
-      <main className="flex-1 p-4">
-        <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-md">
-          <p>
-            このページでは、以下のように曲の分類ができます。<br />
-            - お気に入り度（song_favorite_level）は1〜5段階<br />
-            - 歌えるか歌えないか（can_singing）は 0/1 または未選択
-          </p>
-        </div>
+      <Container sx={{ flex: 1, py: 2 }}>
+        {/* 説明エリア */}
+        <Alert severity="info" sx={{ mb: 3 }}>
+          このページでは、「歌いやすさ(0~4)」と「思い入れ(1~4)」を入力します。<br />
+          0 は「歌えない」(チェックボックス)、1～4 は「歌える度合い」(ラジオボタン)、<br />
+          思い入れは 1～4 段階 です。<br />
+          分類完了した曲でもタップ/クリックで再分類ができます。
+        </Alert>
 
-        {/* ======== Mobile向けUI ======== */}
-        <div className="block md:hidden">
-          <h2 className="text-xl font-semibold mb-2">曲一覧 (Mobile Layout)</h2>
-          {tracks.map((track) => {
-            const updated = updatedTracks.get(track.spotify_track_id);
-            const favoriteValue = updated?.song_favorite_level ?? track.song_favorite_level;
-            const canSinging = updated?.can_singing ?? track.can_singing;
+        {/* モバイル向けタブレイアウト */}
+        <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+          <Tabs value={mobileTab} onChange={handleChangeMobileTab} textColor="primary" indicatorColor="primary">
+            <Tab label={`未分類 (${unclassifiedTracks.length}曲)`} />
+            <Tab label={`分類完了 (${completedTracks.length}曲)`} />
+          </Tabs>
 
-            return (
-              <div key={track.spotify_track_id} className="mb-4 border-b pb-2">
-                <div className="flex gap-2">
-                  {track.image_url && (
-                    <Image
-                      src={track.image_url || '/placeholder.png'}
-                      alt={track.name || 'No Album'}
-                      width={64}
-                      height={64}
-                      className="object-cover"
-                    />
-                  )}
-                  <div>
-                    <div className="font-bold">{track.name}</div>
-                    <div className="text-sm text-gray-600">{track.artist_name}</div>
-                  </div>
-                </div>
-
-                {/* MUI - RadioGroup (お気に入り度) */}
-                <div className="mt-2">
-                  <FormControl>
-                    <FormLabel>曲の好き度</FormLabel>
-                    <RadioGroup
-                      row
-                      value={favoriteValue == null ? '' : String(favoriteValue)}
-                      onChange={(e) => {
-                        const val = e.target.value;
-                        // '' => null
-                        if (val === '') {
-                          handleSongFavoriteLevelChange(track.spotify_track_id, null);
-                        } else {
-                          handleSongFavoriteLevelChange(track.spotify_track_id, Number(val));
-                        }
-                      }}
-                    >
-                      {/* ラジオ: 未選択 */}
-                      <FormControlLabel
-                        value=""
-                        control={<Radio />}
-                        label="未選択"
-                      />
-                      {[1,2,3,4,5].map((num) => (
-                        <FormControlLabel
-                          key={num}
-                          value={String(num)}
-                          control={<Radio />}
-                          label={String(num)}
-                        />
-                      ))}
-                    </RadioGroup>
-                  </FormControl>
-                </div>
-
-                {/* MUI - CheckBox (歌えるかどうか) */}
-                <div className="mt-2">
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        checked={canSinging === 1}
-                        onChange={(e) =>
-                          handleCanSingingChange(track.spotify_track_id, e.target.checked)
-                        }
-                      />
-                    }
-                    label="歌える"
-                  />
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        {/* ======== PC向けUI ======== */}
-        <div className="hidden md:block">
-          <h2 className="text-xl font-semibold mb-2">曲一覧 (PC Layout)</h2>
-          <table className="w-full border-collapse">
-            <thead>
-              <tr className="bg-gray-200">
-                <th className="p-2 border">画像</th>
-                <th className="p-2 border">曲名</th>
-                <th className="p-2 border">アーティスト</th>
-                <th className="p-2 border">お気に入り度</th>
-                <th className="p-2 border">歌える？</th>
-              </tr>
-            </thead>
-            <tbody>
-              {tracks.map((track) => {
+          {/* 未分類タブ */}
+          {mobileTab === 0 && (
+            <Box sx={{ mt: 2 }}>
+              {unclassifiedTracks.map((track) => {
                 const updated = updatedTracks.get(track.spotify_track_id);
-                const favoriteValue = updated?.song_favorite_level ?? track.song_favorite_level;
                 const canSinging = updated?.can_singing ?? track.can_singing;
+                const favLevel = updated?.song_favorite_level ?? track.song_favorite_level;
 
                 return (
-                  <tr key={track.spotify_track_id} className="border-b">
-                    <td className="p-2 border text-center">
+                  <Paper key={track.spotify_track_id} sx={{ p: 2, mb: 2 }}>
+                    {/* 画像と曲名 */}
+                    <Box display="flex" gap={2}>
                       {track.image_url && (
                         <Image
-                          src={track.image_url || '/placeholder.png'}
+                          src={track.image_url}
                           alt={track.name || 'No Album'}
                           width={64}
                           height={64}
-                          className="object-cover mx-auto"
+                          style={{ objectFit: 'cover' }}
                         />
                       )}
-                    </td>
-                    <td className="p-2 border">{track.name}</td>
-                    <td className="p-2 border">{track.artist_name}</td>
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight="bold">
+                          {track.name}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {track.artist_name}
+                        </Typography>
+                      </Box>
+                    </Box>
 
-                    {/* お気に入り度 (RadioGroup) */}
-                    <td className="p-2 border">
+                    {/* 歌えない(checkbox) */}
+                    <Box mt={2}>
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            icon={<CheckBoxOutlineBlankIcon />}
+                            checkedIcon={<CloseIcon />}
+                            checked={canSinging === 0}
+                            onChange={(e) =>
+                              handleCannotSingCheck(track.spotify_track_id, e.target.checked)
+                            }
+                          />
+                        }
+                        label="歌えない"
+                      />
+                    </Box>
+
+                    {/* 歌いやすさ ラジオ */}
+                    <Box mt={1}>
                       <FormControl>
-                        <FormLabel>お気に入り度</FormLabel>
+                        <FormLabel>歌いやすさ (1~4)</FormLabel>
                         <RadioGroup
                           row
-                          value={favoriteValue == null ? '' : String(favoriteValue)}
+                          value={
+                            canSinging == null || canSinging === 0 ? '' : String(canSinging)
+                          }
                           onChange={(e) => {
                             const val = e.target.value;
                             if (val === '') {
-                              handleSongFavoriteLevelChange(track.spotify_track_id, null);
+                              handleCanSingingChange(track.spotify_track_id, null);
                             } else {
-                              handleSongFavoriteLevelChange(track.spotify_track_id, Number(val));
+                              handleCanSingingChange(track.spotify_track_id, Number(val));
                             }
                           }}
                         >
-                          <FormControlLabel
-                            value=""
-                            control={<Radio />}
-                            label="未選択"
-                          />
-                          {[1,2,3,4,5].map((num) => (
+                          <FormControlLabel value="" control={<Radio />} label="未選択" />
+                          {[1, 2, 3, 4].map((num) => (
                             <FormControlLabel
                               key={num}
                               value={String(num)}
@@ -298,75 +345,488 @@ export default function TrackClassificationPage() {
                           ))}
                         </RadioGroup>
                       </FormControl>
-                    </td>
+                    </Box>
 
-                    {/* 歌える？ (CheckBox) */}
-                    <td className="p-2 border text-center">
-                      <FormControlLabel
-                        control={
-                          <Checkbox
-                            checked={canSinging === 1}
-                            onChange={(e) =>
-                              handleCanSingingChange(track.spotify_track_id, e.target.checked)
+                    {/* 思い入れ ラジオ */}
+                    <Box mt={1}>
+                      <FormControl>
+                        <FormLabel>思い入れ (1~4)</FormLabel>
+                        <RadioGroup
+                          row
+                          value={favLevel == null ? '' : String(favLevel)}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            if (val === '') {
+                              handleFavoriteLevelChange(track.spotify_track_id, null);
+                            } else {
+                              handleFavoriteLevelChange(track.spotify_track_id, Number(val));
                             }
-                          />
-                        }
-                        label="歌える"
-                      />
-                    </td>
-                  </tr>
+                          }}
+                        >
+                          <FormControlLabel value="" control={<Radio />} label="未選択" />
+                          {[1, 2, 3, 4].map((num) => (
+                            <FormControlLabel
+                              key={num}
+                              value={String(num)}
+                              control={<Radio />}
+                              label={String(num)}
+                            />
+                          ))}
+                        </RadioGroup>
+                      </FormControl>
+                    </Box>
+                  </Paper>
                 );
               })}
-            </tbody>
-          </table>
-        </div>
+            </Box>
+          )}
 
-        {/* 分類完了曲 */}
-        <div className="mt-6">
-          <h3 className="text-lg font-semibold">分類完了曲</h3>
-          <p>入力が完了している楽曲: {completedTracks.length} 曲</p>
-          <div className="mt-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {completedTracks.map((track) => (
-              <div key={track.spotify_track_id} className="border p-2 rounded">
-                {track.image_url && (
-                  <Image
-                    src={track.image_url || '/placeholder.png'}
-                    alt={track.name || 'No Album'}
-                    width={200}
-                    height={200}
-                    className="object-cover"
-                  />
-                )}
-                <div className="mt-2">
-                  <div className="font-bold">{track.name}</div>
-                  <div>{track.artist_name}</div>
-                  <div>
-                    お気に入り度: {track.song_favorite_level ?? '未選択'}
-                    <br />
-                    歌える?:
-                    {track.can_singing === 1
-                      ? '歌える'
-                      : track.can_singing === 0
-                      ? '歌えない'
-                      : '未選択'}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </main>
+          {/* 分類完了タブ */}
+          {mobileTab === 1 && (
+            <Box sx={{ mt: 2 }}>
+              {completedTracks.map((track) => {
+                const editing = isEditing(track.spotify_track_id);
+                if (!editing) {
+                  return (
+                    <Paper
+                      key={track.spotify_track_id}
+                      sx={{ p: 2, mb: 2, cursor: 'pointer' }}
+                      onClick={() => startReclassify(track)}
+                    >
+                      <Box display="flex" gap={2}>
+                        {track.image_url && (
+                          <Image
+                            src={track.image_url}
+                            alt={track.name || 'No Album'}
+                            width={64}
+                            height={64}
+                            style={{ objectFit: 'cover' }}
+                          />
+                        )}
+                        <Box>
+                          <Typography variant="subtitle1" fontWeight="bold">
+                            {track.name}
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {track.artist_name}
+                          </Typography>
+                        </Box>
+                      </Box>
+                      <Typography variant="body2" sx={{ mt: 1 }}>
+                        歌いやすさ: {track.can_singing === 0 ? '歌えない(×)' : track.can_singing}
+                        <br />
+                        思い入れ: {track.song_favorite_level}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        (タップで再分類)
+                      </Typography>
+                    </Paper>
+                  );
+                } else {
+                  // 編集UI
+                  return (
+                    <Paper key={track.spotify_track_id} sx={{ p: 2, mb: 2 }}>
+                      <Box display="flex" gap={2}>
+                        {track.image_url && (
+                          <Image
+                            src={track.image_url}
+                            alt={track.name || 'No Album'}
+                            width={64}
+                            height={64}
+                            style={{ objectFit: 'cover' }}
+                          />
+                        )}
+                        <Box>
+                          <Typography variant="subtitle1" fontWeight="bold">
+                            {track.name}
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {track.artist_name}
+                          </Typography>
+                        </Box>
+                      </Box>
+
+                      <Box mt={2}>
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              icon={<CheckBoxOutlineBlankIcon />}
+                              checkedIcon={<CloseIcon />}
+                              checked={tempCanSinging === 0}
+                              onChange={(e) =>
+                                setTempCanSinging(e.target.checked ? 0 : null)
+                              }
+                            />
+                          }
+                          label="歌えない"
+                        />
+
+                        <Box mt={2}>
+                          <FormLabel>歌いやすさ (1~4)</FormLabel>
+                          <RadioGroup
+                            row
+                            value={
+                              tempCanSinging == null || tempCanSinging === 0
+                                ? ''
+                                : String(tempCanSinging)
+                            }
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === '') {
+                                setTempCanSinging(null);
+                              } else {
+                                setTempCanSinging(Number(val));
+                              }
+                            }}
+                          >
+                            <FormControlLabel value="" control={<Radio />} label="未選択" />
+                            {[1, 2, 3, 4].map((num) => (
+                              <FormControlLabel
+                                key={num}
+                                value={String(num)}
+                                control={<Radio />}
+                                label={String(num)}
+                              />
+                            ))}
+                          </RadioGroup>
+                        </Box>
+
+                        <Box mt={2}>
+                          <FormLabel>思い入れ (1~4)</FormLabel>
+                          <RadioGroup
+                            row
+                            value={tempFavoriteLevel == null ? '' : String(tempFavoriteLevel)}
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === '') {
+                                setTempFavoriteLevel(null);
+                              } else {
+                                setTempFavoriteLevel(Number(val));
+                              }
+                            }}
+                          >
+                            <FormControlLabel value="" control={<Radio />} label="未選択" />
+                            {[1, 2, 3, 4].map((num) => (
+                              <FormControlLabel
+                                key={num}
+                                value={String(num)}
+                                control={<Radio />}
+                                label={String(num)}
+                              />
+                            ))}
+                          </RadioGroup>
+                        </Box>
+                      </Box>
+
+                      <Box mt={2} display="flex" justifyContent="flex-end" gap={1}>
+                        <Button variant="outlined" onClick={cancelReclassify}>
+                          キャンセル
+                        </Button>
+                        <Button variant="contained" onClick={saveReclassify}>
+                          保存
+                        </Button>
+                      </Box>
+                    </Paper>
+                  );
+                }
+              })}
+            </Box>
+          )}
+        </Box>
+
+        {/* PC Layout */}
+        <Box sx={{ display: { xs: 'none', md: 'block' } }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            曲一覧 (PC Layout)
+          </Typography>
+
+          {/* テーブル表示 */}
+          <TableContainer component={Paper}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell align="center">画像</TableCell>
+                  <TableCell>曲名</TableCell>
+                  <TableCell>アーティスト</TableCell>
+                  <TableCell align="center">歌えない</TableCell>
+                  <TableCell>歌いやすさ</TableCell>
+                  <TableCell>思い入れ</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {tracks.map((track) => {
+                  const updated = updatedTracks.get(track.spotify_track_id);
+                  const canSinging = updated?.can_singing ?? track.can_singing;
+                  const favLevel = updated?.song_favorite_level ?? track.song_favorite_level;
+
+                  return (
+                    <TableRow key={track.spotify_track_id}>
+                      <TableCell align="center">
+                        {track.image_url && (
+                          <Image
+                            src={track.image_url}
+                            alt={track.name || 'No Album'}
+                            width={64}
+                            height={64}
+                            style={{ objectFit: 'cover' }}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell>{track.name}</TableCell>
+                      <TableCell>{track.artist_name}</TableCell>
+                      <TableCell align="center">
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              icon={<CheckBoxOutlineBlankIcon />}
+                              checkedIcon={<CloseIcon />}
+                              checked={canSinging === 0}
+                              onChange={(e) =>
+                                handleCannotSingCheck(track.spotify_track_id, e.target.checked)
+                              }
+                            />
+                          }
+                          label=""
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <FormControl>
+                          <FormLabel>歌いやすさ</FormLabel>
+                          <RadioGroup
+                            row
+                            value={
+                              canSinging == null || canSinging === 0 ? '' : String(canSinging)
+                            }
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === '') {
+                                handleCanSingingChange(track.spotify_track_id, null);
+                              } else {
+                                handleCanSingingChange(track.spotify_track_id, Number(val));
+                              }
+                            }}
+                          >
+                            <FormControlLabel value="" control={<Radio />} label="未選択" />
+                            {[1, 2, 3, 4].map((num) => (
+                              <FormControlLabel
+                                key={num}
+                                value={String(num)}
+                                control={<Radio />}
+                                label={String(num)}
+                              />
+                            ))}
+                          </RadioGroup>
+                        </FormControl>
+                      </TableCell>
+                      <TableCell>
+                        <FormControl>
+                          <FormLabel>思い入れ</FormLabel>
+                          <RadioGroup
+                            row
+                            value={favLevel == null ? '' : String(favLevel)}
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === '') {
+                                handleFavoriteLevelChange(track.spotify_track_id, null);
+                              } else {
+                                handleFavoriteLevelChange(track.spotify_track_id, Number(val));
+                              }
+                            }}
+                          >
+                            <FormControlLabel value="" control={<Radio />} label="未選択" />
+                            {[1, 2, 3, 4].map((num) => (
+                              <FormControlLabel
+                                key={num}
+                                value={String(num)}
+                                control={<Radio />}
+                                label={String(num)}
+                              />
+                            ))}
+                          </RadioGroup>
+                        </FormControl>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          {/* 分類完了曲 (再分類) */}
+          <Box mt={4}>
+            <Typography variant="subtitle1" fontWeight="bold">
+              分類完了曲: {completedTracks.length} 曲
+            </Typography>
+            <Box
+              mt={2}
+              display="grid"
+              gridTemplateColumns="repeat(auto-fill, minmax(300px, 1fr))"
+              gap={2}
+            >
+              {completedTracks.map((track) => {
+                const editing = isEditing(track.spotify_track_id);
+
+                if (!editing) {
+                  return (
+                    <Card
+                      key={track.spotify_track_id}
+                      sx={{ cursor: 'pointer' }}
+                      onClick={() => startReclassify(track)}
+                    >
+                      {track.image_url && (
+                        <CardMedia
+                          component="img"
+                          height="200"
+                          image={track.image_url}
+                          alt={track.name || 'No Album'}
+                        />
+                      )}
+                      <CardContent>
+                        <Typography variant="subtitle1" fontWeight="bold">
+                          {track.name}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {track.artist_name}
+                        </Typography>
+                        <Typography variant="body2" sx={{ mt: 1 }}>
+                          歌いやすさ:{' '}
+                          {track.can_singing === 0 ? '歌えない(×)' : track.can_singing}
+                          <br />
+                          思い入れ: {track.song_favorite_level}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          (クリックで再分類)
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  );
+                } else {
+                  // 編集UI
+                  return (
+                    <Card key={track.spotify_track_id}>
+                      {track.image_url && (
+                        <CardMedia
+                          component="img"
+                          height="200"
+                          image={track.image_url}
+                          alt={track.name || 'No Album'}
+                        />
+                      )}
+                      <CardContent>
+                        <Typography variant="subtitle1" fontWeight="bold">
+                          {track.name}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {track.artist_name}
+                        </Typography>
+
+                        <Box mt={2}>
+                          <FormControlLabel
+                            control={
+                              <Checkbox
+                                icon={<CheckBoxOutlineBlankIcon />}
+                                checkedIcon={<CloseIcon />}
+                                checked={tempCanSinging === 0}
+                                onChange={(e) =>
+                                  setTempCanSinging(e.target.checked ? 0 : null)
+                                }
+                              />
+                            }
+                            label="歌えない"
+                          />
+                        </Box>
+
+                        <Box mt={2}>
+                          <FormLabel>歌いやすさ (1~4)</FormLabel>
+                          <RadioGroup
+                            row
+                            value={
+                              tempCanSinging == null || tempCanSinging === 0
+                                ? ''
+                                : String(tempCanSinging)
+                            }
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === '') {
+                                setTempCanSinging(null);
+                              } else {
+                                setTempCanSinging(Number(val));
+                              }
+                            }}
+                          >
+                            <FormControlLabel value="" control={<Radio />} label="未選択" />
+                            {[1, 2, 3, 4].map((num) => (
+                              <FormControlLabel
+                                key={num}
+                                value={String(num)}
+                                control={<Radio />}
+                                label={String(num)}
+                              />
+                            ))}
+                          </RadioGroup>
+                        </Box>
+
+                        <Box mt={2}>
+                          <FormLabel>思い入れ (1~4)</FormLabel>
+                          <RadioGroup
+                            row
+                            value={tempFavoriteLevel == null ? '' : String(tempFavoriteLevel)}
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === '') {
+                                setTempFavoriteLevel(null);
+                              } else {
+                                setTempFavoriteLevel(Number(val));
+                              }
+                            }}
+                          >
+                            <FormControlLabel value="" control={<Radio />} label="未選択" />
+                            {[1, 2, 3, 4].map((num) => (
+                              <FormControlLabel
+                                key={num}
+                                value={String(num)}
+                                control={<Radio />}
+                                label={String(num)}
+                              />
+                            ))}
+                          </RadioGroup>
+                        </Box>
+
+                        <Box mt={2} display="flex" justifyContent="flex-end" gap={1}>
+                          <Button variant="outlined" onClick={cancelReclassify}>
+                            キャンセル
+                          </Button>
+                          <Button variant="contained" onClick={saveReclassify}>
+                            保存
+                          </Button>
+                        </Box>
+                      </CardContent>
+                    </Card>
+                  );
+                }
+              })}
+            </Box>
+          </Box>
+        </Box>
+      </Container>
 
       {/* フッター */}
-      <footer className="p-4 border-t bg-white text-center sticky bottom-0">
-        <p className="mb-2">現在 {updatedCount} 曲入力されています</p>
-        <button
-          onClick={handleSave}
-          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-        >
+      <Paper
+        sx={{
+          position: 'sticky',
+          bottom: 0,
+          py: 2,
+          textAlign: 'center',
+        }}
+        elevation={3}
+      >
+        <Typography variant="body2" sx={{ mb: 1 }}>
+          現在 {updatedCount} 曲入力されています
+        </Typography>
+        <Button variant="contained" color="primary" onClick={handleSave}>
           保存
-        </button>
-      </footer>
-    </div>
+        </Button>
+      </Paper>
+    </Box>
   );
 }

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -31,6 +31,8 @@ import {
   Card,
   CardMedia,
   CardContent,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 
 import CloseIcon from '@mui/icons-material/Close';
@@ -50,6 +52,10 @@ type TrackData = {
 export default function TrackClassificationPage() {
   const { data: session } = useSession();
   const userId = session?.user?.id;
+
+  // レスポンシブ判定 (md以上かどうか)
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
   // 全楽曲
   const [tracks, setTracks] = useState<TrackData[]>([]);
@@ -175,6 +181,7 @@ export default function TrackClassificationPage() {
   const handleChangeMobileTab = (event: React.SyntheticEvent, newValue: number) => {
     setMobileTab(newValue);
   };
+
   // 未分類の曲
   const unclassifiedTracks = tracks.filter(
     (t) => t.can_singing == null || t.song_favorite_level == null
@@ -226,6 +233,7 @@ export default function TrackClassificationPage() {
         }
       }
 
+      // 分類変更後、updatedTracksの該当エントリを削除（または上書き）する
       setUpdatedTracks((prev) => {
         const newMap = new Map(prev);
         newMap.delete(editingTrackId);
@@ -263,7 +271,12 @@ export default function TrackClassificationPage() {
 
         {/* モバイル向けタブレイアウト */}
         <Box sx={{ display: { xs: 'block', md: 'none' } }}>
-          <Tabs value={mobileTab} onChange={handleChangeMobileTab} textColor="primary" indicatorColor="primary">
+          <Tabs
+            value={mobileTab}
+            onChange={handleChangeMobileTab}
+            textColor="primary"
+            indicatorColor="primary"
+          >
             <Tab label={`未分類 (${unclassifiedTracks.length}曲)`} />
             <Tab label={`分類完了 (${completedTracks.length}曲)`} />
           </Tabs>
@@ -323,7 +336,9 @@ export default function TrackClassificationPage() {
                         <RadioGroup
                           row
                           value={
-                            canSinging == null || canSinging === 0 ? '' : String(canSinging)
+                            canSinging == null || canSinging === 0
+                              ? ''
+                              : String(canSinging)
                           }
                           onChange={(e) => {
                             const val = e.target.value;
@@ -334,7 +349,7 @@ export default function TrackClassificationPage() {
                             }
                           }}
                         >
-                          <FormControlLabel value="" control={<Radio />} label="未選択" />
+                          {/* ラベルを追加するなら: <FormControlLabel value="" control={<Radio />} label="未選択" /> */}
                           {[1, 2, 3, 4].map((num) => (
                             <FormControlLabel
                               key={num}
@@ -363,7 +378,6 @@ export default function TrackClassificationPage() {
                             }
                           }}
                         >
-                          <FormControlLabel value="" control={<Radio />} label="未選択" />
                           {[1, 2, 3, 4].map((num) => (
                             <FormControlLabel
                               key={num}
@@ -479,7 +493,6 @@ export default function TrackClassificationPage() {
                               }
                             }}
                           >
-                            <FormControlLabel value="" control={<Radio />} label="未選択" />
                             {[1, 2, 3, 4].map((num) => (
                               <FormControlLabel
                                 key={num}
@@ -505,7 +518,6 @@ export default function TrackClassificationPage() {
                               }
                             }}
                           >
-                            <FormControlLabel value="" control={<Radio />} label="未選択" />
                             {[1, 2, 3, 4].map((num) => (
                               <FormControlLabel
                                 key={num}
@@ -595,7 +607,9 @@ export default function TrackClassificationPage() {
                           <RadioGroup
                             row
                             value={
-                              canSinging == null || canSinging === 0 ? '' : String(canSinging)
+                              canSinging == null || canSinging === 0
+                                ? ''
+                                : String(canSinging)
                             }
                             onChange={(e) => {
                               const val = e.target.value;
@@ -606,7 +620,6 @@ export default function TrackClassificationPage() {
                               }
                             }}
                           >
-                            <FormControlLabel value="" control={<Radio />} label="未選択" />
                             {[1, 2, 3, 4].map((num) => (
                               <FormControlLabel
                                 key={num}
@@ -633,7 +646,6 @@ export default function TrackClassificationPage() {
                               }
                             }}
                           >
-                            <FormControlLabel value="" control={<Radio />} label="未選択" />
                             {[1, 2, 3, 4].map((num) => (
                               <FormControlLabel
                                 key={num}
@@ -754,7 +766,6 @@ export default function TrackClassificationPage() {
                               }
                             }}
                           >
-                            <FormControlLabel value="" control={<Radio />} label="未選択" />
                             {[1, 2, 3, 4].map((num) => (
                               <FormControlLabel
                                 key={num}
@@ -780,7 +791,6 @@ export default function TrackClassificationPage() {
                               }
                             }}
                           >
-                            <FormControlLabel value="" control={<Radio />} label="未選択" />
                             {[1, 2, 3, 4].map((num) => (
                               <FormControlLabel
                                 key={num}
@@ -810,23 +820,25 @@ export default function TrackClassificationPage() {
         </Box>
       </Container>
 
-      {/* フッター */}
-      <Paper
-        sx={{
-          position: 'sticky',
-          bottom: 0,
-          py: 2,
-          textAlign: 'center',
-        }}
-        elevation={3}
-      >
-        <Typography variant="body2" sx={{ mb: 1 }}>
-          現在 {updatedCount} 曲入力されています
-        </Typography>
-        <Button variant="contained" color="primary" onClick={handleSave}>
-          保存
-        </Button>
-      </Paper>
+      {/* フッター (未分類タブまたはPCレイアウト時のみ表示) */}
+      {(mobileTab === 0 || isDesktop) && (
+        <Paper
+          sx={{
+            position: 'sticky',
+            bottom: 0,
+            py: 2,
+            textAlign: 'center',
+          }}
+          elevation={3}
+        >
+          <Typography variant="body2" sx={{ mb: 1 }}>
+            現在 {updatedCount} 曲入力されています
+          </Typography>
+          <Button variant="contained" color="primary" onClick={handleSave}>
+            保存
+          </Button>
+        </Paper>
+      )}
     </Box>
   );
 }

--- a/src/pages/playlist.tsx
+++ b/src/pages/playlist.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import { supabase } from '@/utils/supabaseClient';
-import Image from 'next/image';
 
 // ユーザー情報の型 (最低限)
 type UserData = {


### PR DESCRIPTION
# Summary

- 主にモバイル版でのUIを大きく変更しています。PC版の画面は機能の確認のためそこまでUIを整えるようなことはしていません。

# モバイル版のUIについて

- 「歌えない」ボタンについて、要件定義のようにチェックボックスで別枠として作成し、チェックボックスに入力された時チェックボックスが×で表示されるように実装している。
- 「歌いやすさ」「思い入れ」について、ラジオボタンでそれぞれ評価できるようになっています。
- 歌いやすさを入力した時には歌えないボタンでの入力がキャンセルされ（「歌えない」ボタンは歌いやすさが入力されていない時にのみ入力を反映する）、歌いやすさが評価されているのに「歌えない」が入力されないようになっている
- 歌いやすさと思い入れの二つが入力されているときに「現在〇〇曲入力されています。」という表示を更新する
- 保存ボタンが押された時DBにインサートして分類完了曲の方に表示が移るようになっている

- 分類完了タブについて、分類完了された曲がまとめて表示されるようになっている
- 分類完了された曲を再評価できるようにするために楽曲のカード表示されている部分をタップすると再評価のUIを表示する
- 再評価した楽曲はカード内の保存ボタンから評価を保存することができる

<追記>
- 歌いやすさと思い入れの部分の未選択のラジオボタンを削除しました（未選択をユーザーに選択させないようにするため）
- 保存が完了した時に「保存が完了しました！」というポップアップを表示する機能を追加しました。

# images

<img width="1920" alt="スクリーンショット 2025-01-12 2 36 01" src="https://github.com/user-attachments/assets/c2ec2a15-064b-4381-b9ea-83cb1c614c78" />
<img width="1920" alt="スクリーンショット 2025-01-12 2 36 06" src="https://github.com/user-attachments/assets/e88f84b6-1ffa-480c-a606-643f782b2751" />
