### PR TITLE
セッションページの追加とSDLによる曲の自己開示度分類の作成

### DIFF
--- a/src/pages/api/tracks.ts
+++ b/src/pages/api/tracks.ts
@@ -1,30 +1,92 @@
-// pages/api/tracks.ts
 import { NextApiRequest, NextApiResponse } from 'next';
-import { supabase } from '@/utils/supabaseClient';  // あなたのSupabaseクライアントへのパス
+import { supabase } from '@/utils/supabaseClient';
 
 // 受け取るデータの型
 type TrackUpdateData = {
   spotify_track_id: string;
-  user_id: string;           // ログイン中のユーザーID（spotify_user_id） 
-  song_favorite_level?: number | null;
-  can_singing?: boolean | null;
+  user_id: string;           // ログイン中のユーザーID（spotify_user_id）
+  song_favorite_level?: number | null; // 1~4
+  can_singing?: number | null;         // 0~4
 };
+
+// ★ self_disclosure_level を計算する関数
+function computeSelfDisclosureLevel(
+  songFavorite?: number | null,
+  canSinging?: number | null,
+  popularity?: number
+): number {
+  const hasAffection = songFavorite && songFavorite >= 3; // true => 'ある', false => 'ない'
+  const hasConfidence = (canSinging && canSinging >= 3);
+  const isHighPopularity = (popularity && popularity > 50);
+
+  if (!hasAffection && !hasConfidence && !isHighPopularity) {
+    return 0; // 歌うべきではない
+  } else if (!hasAffection && hasConfidence && isHighPopularity) {
+    return 1;
+  } else if (!hasAffection && !hasConfidence && isHighPopularity) {
+    return 1;
+  } else if (!hasAffection && hasConfidence && !isHighPopularity) {
+    return 2;
+  } else if (hasAffection && hasConfidence && isHighPopularity) {
+    return 2;
+  } else if (hasAffection && !hasConfidence && isHighPopularity) {
+    return 3;
+  } else if (hasAffection && hasConfidence && !isHighPopularity) {
+    return 3;
+  } else if (hasAffection && !hasConfidence && !isHighPopularity) {
+    return 4;
+  } else {
+    return 0;
+  }
+}
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'PUT') {
     try {
-      // PUTリクエストで渡されるであろう JSON ボディをパース
       const { trackUpdates } = req.body as { trackUpdates: TrackUpdateData[] };
-
-      // trackUpdatesは配列で受け取る想定
       if (!Array.isArray(trackUpdates)) {
         return res.status(400).json({ error: 'Invalid request body' });
       }
 
+      // Spotify Track IDリストを抽出
+      const spotifyTrackIds = trackUpdates.map((track) => track.spotify_track_id);
+
+      // DBから関連するtracksデータをfetch
+      const { data: trackData, error: fetchError } = await supabase
+        .from('tracks')
+        .select('spotify_track_id, popularity') // 必要なカラムだけ取得
+        .in('spotify_track_id', spotifyTrackIds);
+
+      if (fetchError || !trackData) {
+        console.error('[tracks API] fetch error:', fetchError);
+        return res.status(500).json({ error: 'Failed to fetch track data' });
+      }
+
+      // spotify_track_idをキーにしたMapを作成
+      const trackPopularityMap = new Map(
+        trackData.map((track) => [track.spotify_track_id, track.popularity])
+      );
+
+      // trackUpdatesにself_disclosure_levelを追加
+      const updatesWithDisclosure = trackUpdates.map((track) => {
+        const { song_favorite_level, can_singing, spotify_track_id } = track;
+        const popularity = trackPopularityMap.get(spotify_track_id) || 0; // 人気度を取得
+        const selfDisclosure = computeSelfDisclosureLevel(
+          song_favorite_level,
+          can_singing,
+          popularity
+        );
+
+        return {
+          ...track,
+          self_disclosure_level: selfDisclosure, // ★ new column
+        };
+      });
+
       // Supabaseの upsert で一括保存
       const { data, error } = await supabase
         .from('tracks')
-        .upsert(trackUpdates, {
+        .upsert(updatesWithDisclosure, {
           onConflict: 'spotify_track_id',
         });
 
@@ -40,7 +102,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   }
 
-  // それ以外のメソッドは 405 を返す
   res.setHeader('Allow', ['PUT']);
   return res.status(405).json({ error: 'Method not allowed' });
 }

--- a/src/pages/phases/dialog.tsx
+++ b/src/pages/phases/dialog.tsx
@@ -1,0 +1,121 @@
+// pages/phases/dialog.tsx
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { supabase } from '@/utils/supabaseClient';
+
+export default function DialogPage() {
+  const router = useRouter();
+  const { session_id, phase_id, phase_numbers, directions } = router.query;
+
+  const [sessionDirections, setSessionDirections] = useState<number | null>(null);
+
+  // 1) DBの sessions.directions を取得
+  useEffect(() => {
+    if (!session_id) return;
+    const fetchSessionDirections = async () => {
+      const { data, error } = await supabase
+        .from('sessions')
+        .select('directions')
+        .eq('id', session_id)
+        .single();
+      if (error || !data) {
+        console.error('Failed to fetch sessions.directions', error);
+        return;
+      }
+      setSessionDirections(data.directions);
+    };
+    fetchSessionDirections();
+  }, [session_id]);
+
+  const phaseNum = phase_numbers ? Number(phase_numbers) : 1;
+  const urlDirections = directions ? Number(directions) : 0;
+
+  // 「次の画面へ戻る」ボタン押下時
+  // 質問文で「router.push で index.tsxへ戻る」とある想定
+  // 1) directionsがDBに入っている値と一緒の場合 => directionsのみ反転
+  // 2) 違う場合 => directions反転 + phaseNum++
+  const handleNext = async () => {
+    if (sessionDirections === null) return; // まだ取得できていない場合はreturn
+
+    const newDirections = urlDirections === 1 ? 0 : 1; // 反転
+    let newPhaseNum = phaseNum;                     // デフォルトは変更なし
+
+    if (sessionDirections !== urlDirections ) {
+      // DBのdirections と URL のdirections が違う → 2) の処理
+      newPhaseNum = phaseNum + 1;
+      
+      try {
+        if (newPhaseNum !== 9) {
+          const { data: phasesData, error: phasesError } = await supabase
+            .from('phases')
+            .insert([
+              {
+                session_id: session_id,
+                phase_numbers: newPhaseNum,
+              },
+            ])
+            .select();
+          if (phasesError) {
+            console.error('Error inserting into phases:', phasesError);
+            alert('phasesレコード作成に失敗しました');
+            return;
+          }
+          if (!phasesData || phasesData.length === 0) {
+            alert('phasesレコードが作れませんでした');
+            return;
+          }
+    
+          const newPhase = phasesData[0];
+          console.log('Created phase:', newPhase);
+
+          router.push({
+            pathname: '/phases', // index.tsx
+            query: {
+              session_id,
+              phase_id: newPhase.id,           // 質問文: 変更しない
+              phase_numbers: newPhase.phase_numbers,
+              directions: newDirections,
+            },
+          });
+        }else {
+          router.push({
+            pathname: '/phases', // index.tsx
+            query: {
+              phase_numbers: newPhaseNum,
+            },
+          });
+        }
+      } catch (err) {
+        console.error('handleCreateSession error:', err);
+      }
+    }else{
+      // session_id, phase_id は変えず
+      router.push({
+        pathname: '/phases', // index.tsx
+        query: {
+          session_id,
+          phase_id,           // 質問文: 変更しない
+          phase_numbers: newPhaseNum,
+          directions: newDirections,
+        },
+      });
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1>対話をしてください。</h1>
+      <p>対話の後は評価をしてください</p>
+
+      <div className="mt-6">
+        <button
+          onClick={handleNext}
+          className="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600"
+        >
+          次へ
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/phases/player.tsx
+++ b/src/pages/phases/player.tsx
@@ -1,0 +1,75 @@
+// pages/phases/player.tsx
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { supabase } from '@/utils/supabaseClient';
+
+export default function PlayerPage() {
+  const router = useRouter();
+  const { session_id, phase_id, phase_numbers, directions } = router.query;
+
+  // phasesテーブルから select_tracks, select_tracks_user_id を取得
+  const [selectedTrackId, setSelectedTrackId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!phase_id) return;
+
+    const fetchPhase = async () => {
+      const { data, error } = await supabase
+        .from('phases')
+        .select('select_tracks, select_tracks_user_id')
+        .eq('id', phase_id)
+        .single();
+
+      if (error || !data) {
+        console.error('Failed to fetch phases:', error);
+        return;
+      }
+      setSelectedTrackId(data.select_tracks);
+    };
+    fetchPhase();
+  }, [phase_id]);
+
+  const handleGotoDialogue = () => {
+    // ページ下部に「対話セクションに移動する」ボタン → /phases/dialog
+    router.push({
+      pathname: '/phases/dialog',
+      query: {
+        session_id,
+        phase_id,
+        phase_numbers,
+        directions
+      }
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <h1>曲の再生ページ</h1>
+      {selectedTrackId ? (
+        <div className="mt-4">
+          <p>選択されたTrackID: {selectedTrackId}</p>
+          {/* iframe埋め込み 30秒プレビュー */}
+          <iframe
+            src={`https://open.spotify.com/embed/track/${selectedTrackId}`}
+            width="100%"
+            height="80"
+            frameBorder="0"
+            allow="encrypted-media"
+          />
+        </div>
+      ) : (
+        <p>まだ曲が選択されていません</p>
+      )}
+
+      <div className="mt-6">
+        <button
+          onClick={handleGotoDialogue}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        >
+          対話セクションに移動する
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary
- フェーズの進行や各セッションでの流れを案内するページの作成
- 自己開示度をAPI上で計算し、DBに格納する実装
- SDLの分類は確実な分類ができていることを確認した。