### PR TITLE
DB関連の部分の修正

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -16,14 +16,14 @@ export async function saveTracksToSupabase(tracks: TrackToSave[]): Promise<void>
   if (tracks.length === 0) return;
 
   // まずは user_id と track_id を抜き出す
-  const userId = tracks[0].user_id; 
+  const userId = tracks[0].user_id;
   // （基本的には同一ユーザーでまとめて渡してくる想定とする）
 
   const trackIds = tracks.map((track) => track.spotify_track_id);
 
   // 既存のレコードを取得 (同じ user_id & trackIds のレコードのみ)
   const { data: existingTracks, error: fetchError } = await supabase
-    .from('tracks')
+    .from('track2')
     .select('spotify_track_id, user_id, song_favorite_level, can_singing')
     .eq('user_id', userId)
     .in('spotify_track_id', trackIds);
@@ -56,9 +56,9 @@ export async function saveTracksToSupabase(tracks: TrackToSave[]): Promise<void>
   // マージ後のデータをアップサート
   // Supabase 側で UNIQUE(spotify_track_id, user_id) が設定されている前提
   const { data, error } = await supabase
-    .from('tracks')
+    .from('track2')
     .upsert(mergedTracks, {
-      onConflict: 'spotify_track_id,user_id', 
+      onConflict: 'spotify_track_id, user_id',
     });
 
   if (error) {

--- a/src/pages/api/tracks.ts
+++ b/src/pages/api/tracks.ts
@@ -53,7 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // DBから関連するtracksデータをfetch
       const { data: trackData, error: fetchError } = await supabase
-        .from('tracks')
+        .from('track2')
         .select('spotify_track_id, popularity') // 必要なカラムだけ取得
         .in('spotify_track_id', spotifyTrackIds);
 
@@ -85,9 +85,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Supabaseの upsert で一括保存
       const { data, error } = await supabase
-        .from('tracks')
+        .from('track2')
         .upsert(updatesWithDisclosure, {
-          onConflict: 'spotify_track_id',
+          onConflict: 'spotify_track_id, user_id',
         });
 
       if (error) {

--- a/src/pages/ipad/phaseA/dialog.tsx
+++ b/src/pages/ipad/phaseA/dialog.tsx
@@ -22,7 +22,7 @@ export default function DialogPage() {
     if (urlDirections === 1) {
       try {
         const { data: phasesData, error: phasesError } = await supabase
-          .from('phases')
+          .from('phases2')
           .insert([
             {
               session_id: session_id,
@@ -59,7 +59,7 @@ export default function DialogPage() {
       newPhaseNum = phaseNum + 1;
 
       const { data: phasesData, error: phasesError } = await supabase
-        .from('phases')
+        .from('phases2')
         .insert([
           {
             session_id: session_id,

--- a/src/pages/ipad/phaseA/index.tsx
+++ b/src/pages/ipad/phaseA/index.tsx
@@ -47,7 +47,7 @@ export default function PhasesPage() {
 
     const fetchSessionUsers = async () => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from('sessions2')
         .select('user_a, user_b')
         .eq('id', session_id)
         .single();
@@ -69,7 +69,7 @@ export default function PhasesPage() {
 
     const fetchUserATracks = async () => {
       const { data, error } = await supabase
-        .from('tracks')
+        .from('track2')
         .select('*')
         .neq('self_disclosure_level', 0)
         .eq('user_id', userA);
@@ -132,7 +132,7 @@ export default function PhasesPage() {
     const userASpotifyId = userAData.spotify_user_id;
 
     const { error: upError } = await supabase
-      .from('phases')
+      .from('phases2')
       .update({
         select_tracks: selectedTrack,
         select_tracks_user_id: userASpotifyId,
@@ -175,7 +175,7 @@ export default function PhasesPage() {
     const userBSpotifyId = userBData.spotify_user_id;
 
     const { error: upError } = await supabase
-      .from('phases')
+      .from('phases2')
       .update({
         select_tracks: selectedTrack,
         select_tracks_user_id: userBSpotifyId,

--- a/src/pages/ipad/phaseA/index.tsx
+++ b/src/pages/ipad/phaseA/index.tsx
@@ -85,7 +85,7 @@ export default function PhasesPage() {
 
     const fetchUserBTracks = async () => {
       const { data, error } = await supabase
-        .from('tracks')
+        .from('track2')
         .select('*')
         .neq('self_disclosure_level', 0)
         .eq('user_id', userB);

--- a/src/pages/ipad/phaseA/player.tsx
+++ b/src/pages/ipad/phaseA/player.tsx
@@ -120,7 +120,7 @@ export default function PlayerPage() {
     if (!phase_id) return;
     const fetchPhase = async () => {
       const { data, error } = await supabase
-        .from('phases')
+        .from('phases2')
         .select('select_tracks')
         .eq('id', phase_id)
         .single();

--- a/src/pages/ipad/phaseB/dialog.tsx
+++ b/src/pages/ipad/phaseB/dialog.tsx
@@ -22,7 +22,7 @@ export default function DialogPage() {
     if (urlDirections === 1) {
       try {
         const { data: phasesData, error: phasesError } = await supabase
-          .from('phases')
+          .from('phases2')
           .insert([
             {
               session_id: session_id,
@@ -59,7 +59,7 @@ export default function DialogPage() {
       newPhaseNum = phaseNum + 1;
 
       const { data: phasesData, error: phasesError } = await supabase
-        .from('phases')
+        .from('phases2')
         .insert([
           {
             session_id: session_id,

--- a/src/pages/ipad/phaseB/index.tsx
+++ b/src/pages/ipad/phaseB/index.tsx
@@ -60,7 +60,7 @@ export default function PhasesPage() {
 
     const fetchSessionUsers = async () => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from('sessions2')
         .select('user_a, user_b')
         .eq('id', session_id)
         .single();
@@ -82,9 +82,9 @@ export default function PhasesPage() {
   const fetchAlreadySelectedTrackIds = useCallback(async (userId: string) => {
     // phasesテーブルの select_tracks_user_id が該当ユーザーになっている行の select_tracks を収集
     const { data, error } = await supabase
-      .from('phases')
-      .select('select_tracks')
-      .eq('select_tracks_user_id', userId)
+      .from('logs2')
+      .select('selected_track')
+      .eq('user_id', userId)
       .eq('session_id', session_id)
 
     if (error) {
@@ -96,7 +96,7 @@ export default function PhasesPage() {
     }
 
     // select_tracks カラムには1つのトラックID(string)が入っている想定
-    const selectedIds = data.map((row) => row.select_tracks).filter(Boolean);
+    const selectedIds = data.map((row) => row.selected_track).filter(Boolean);
     return selectedIds;
   }, [session_id]);
 
@@ -116,7 +116,7 @@ export default function PhasesPage() {
 
       // --- (1) 優先度の高い self_disclosure_level の曲を取得 (0 は除外) ---
       let query = supabase
-        .from('tracks')
+        .from('track2')
         .select('*')
         .eq('user_id', userId)
         .neq('self_disclosure_level', 0)
@@ -139,7 +139,7 @@ export default function PhasesPage() {
       // --- (2) 4件に満たない場合はフォールバックを追加 ---
       if (combined.length < 4 && fallback.length > 0) {
         let fallbackQuery = supabase
-          .from('tracks')
+          .from('track2')
           .select('*')
           .eq('user_id', userId)
           .neq('self_disclosure_level', 0)
@@ -206,7 +206,7 @@ export default function PhasesPage() {
     // logsテーブルへインサート
     try {
       const { error: logError } = await supabase
-        .from('logs')
+        .from('logs2')
         .insert([
           {
             session_id: session_id,
@@ -228,7 +228,7 @@ export default function PhasesPage() {
 
     // phasesテーブル更新
     const { error } = await supabase
-      .from('phases')
+      .from('phases2')
       .update({
         select_tracks: selectedTrack,
         select_tracks_user_id: userASpotifyId,
@@ -269,7 +269,7 @@ export default function PhasesPage() {
     // logsテーブルへインサート
     try {
       const { error: logError } = await supabase
-        .from('logs')
+        .from('logs2')
         .insert([
           {
             session_id: session_id,
@@ -291,7 +291,7 @@ export default function PhasesPage() {
 
     // phasesテーブル更新
     const { error } = await supabase
-      .from('phases')
+      .from('phases2')
       .update({
         select_tracks: selectedTrack,
         select_tracks_user_id: userBSpotifyId,

--- a/src/pages/ipad/phaseB/player.tsx
+++ b/src/pages/ipad/phaseB/player.tsx
@@ -120,7 +120,7 @@ export default function PlayerPage() {
     if (!phase_id) return;
     const fetchPhase = async () => {
       const { data, error } = await supabase
-        .from('phases')
+        .from('phases2')
         .select('select_tracks')
         .eq('id', phase_id)
         .single();

--- a/src/pages/ipad/sessionA/index.tsx
+++ b/src/pages/ipad/sessionA/index.tsx
@@ -13,8 +13,8 @@ type UserData = {
 export default function NewSessionPage() {
   const router = useRouter();
   const [users, setUsers] = useState<UserData[]>([]);
-  const [userA, setUserA] = useState('');       // sessions.user_a
-  const [userB, setUserB] = useState('');       // sessions.user_b
+  const [userA, setUserA] = useState('');       // sessions2.user_a
+  const [userB, setUserB] = useState('');       // sessions2.user_b
 
   useEffect(() => {
     const fetchUsers = async () => {
@@ -32,9 +32,9 @@ export default function NewSessionPage() {
 
   const handleCreateSession = async () => {
     try {
-      // 1) sessionsに INSERT
-      const { data: sessionsData, error: sessionsError } = await supabase
-        .from('sessions')
+      // 1) sessions2に INSERT
+      const { data: sessions2Data, error: sessions2Error } = await supabase
+        .from('sessions2')
         .insert([
           {
             user_a: userA,
@@ -44,21 +44,21 @@ export default function NewSessionPage() {
         ])
         .select(); // returning
 
-      if (sessionsError) {
-        console.error('Error inserting into sessions:', sessionsError);
+      if (sessions2Error) {
+        console.error('Error inserting into sessions2:', sessions2Error);
         alert('セッション作成に失敗しました');
         return;
       }
-      if (!sessionsData || sessionsData.length === 0) {
+      if (!sessions2Data || sessions2Data.length === 0) {
         alert('セッション作成に失敗しました(データなし)');
         return;
       }
-      const newSession = sessionsData[0];
+      const newSession = sessions2Data[0];
       console.log('Created session:', newSession);
 
       // 2) phasesに INSERT (session_id & directions=1)
       const { data: phasesData, error: phasesError } = await supabase
-        .from('phases')
+        .from('phases2')
         .insert([
           {
             session_id: newSession.id,

--- a/src/pages/ipad/sessionB/index.tsx
+++ b/src/pages/ipad/sessionB/index.tsx
@@ -13,8 +13,8 @@ type UserData = {
 export default function NewSessionPage() {
   const router = useRouter();
   const [users, setUsers] = useState<UserData[]>([]);
-  const [userA, setUserA] = useState('');       // sessions.user_a
-  const [userB, setUserB] = useState('');       // sessions.user_b
+  const [userA, setUserA] = useState('');       // sessions2.user_a
+  const [userB, setUserB] = useState('');       // sessions2.user_b
 
   useEffect(() => {
     const fetchUsers = async () => {
@@ -32,9 +32,9 @@ export default function NewSessionPage() {
 
   const handleCreateSession = async () => {
     try {
-      // 1) sessionsに INSERT
-      const { data: sessionsData, error: sessionsError } = await supabase
-        .from('sessions')
+      // 1) sessions2に INSERT
+      const { data: sessions2Data, error: sessions2Error } = await supabase
+        .from('sessions2')
         .insert([
           {
             user_a: userA,
@@ -44,21 +44,21 @@ export default function NewSessionPage() {
         ])
         .select(); // returning
 
-      if (sessionsError) {
-        console.error('Error inserting into sessions:', sessionsError);
+      if (sessions2Error) {
+        console.error('Error inserting into sessions2:', sessions2Error);
         alert('セッション作成に失敗しました');
         return;
       }
-      if (!sessionsData || sessionsData.length === 0) {
+      if (!sessions2Data || sessions2Data.length === 0) {
         alert('セッション作成に失敗しました(データなし)');
         return;
       }
-      const newSession = sessionsData[0];
+      const newSession = sessions2Data[0];
       console.log('Created session:', newSession);
 
       // 2) phasesに INSERT (session_id & directions=1)
-      const { data: phasesData, error: phasesError } = await supabase
-        .from('phases')
+      const { data: phases2Data, error: phases2Error } = await supabase
+        .from('phases2')
         .insert([
           {
             session_id: newSession.id,
@@ -67,17 +67,17 @@ export default function NewSessionPage() {
           },
         ])
         .select();
-      if (phasesError) {
-        console.error('Error inserting into phases:', phasesError);
+      if (phases2Error) {
+        console.error('Error inserting into phases:', phases2Error);
         alert('phasesレコード作成に失敗しました');
         return;
       }
-      if (!phasesData || phasesData.length === 0) {
+      if (!phases2Data || phases2Data.length === 0) {
         alert('phasesレコードが作れませんでした');
         return;
       }
 
-      const newPhase = phasesData[0];
+      const newPhase = phases2Data[0];
       console.log('Created phase:', newPhase);
 
       // 3) router.push で /phases に飛ぶ

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -57,7 +57,7 @@ export default function TrackClassificationPage() {
 
     const fetchTracks = async () => {
       const { data, error } = await supabase
-        .from('tracks')
+        .from('track2')
         .select('*')
         .eq('user_id', userId);
 
@@ -159,7 +159,7 @@ export default function TrackClassificationPage() {
       // 成功時 => updatedTracksクリア & DB再取得
       setUpdatedTracks(new Map());
       const { data, error } = await supabase
-        .from('tracks')
+        .from('track2')
         .select('*')
         .eq('user_id', userId);
       if (error) {
@@ -229,7 +229,7 @@ export default function TrackClassificationPage() {
         console.error('Failed to upsert track', await res.text());
       } else {
         const { data, error } = await supabase
-          .from('tracks')
+          .from('track2')
           .select('*')
           .eq('user_id', userId);
         if (!error && data) {

--- a/src/pages/mobile/phasesA/dialog.tsx
+++ b/src/pages/mobile/phasesA/dialog.tsx
@@ -10,17 +10,17 @@ export default function DialogPage() {
 
   const [sessionDirections, setSessionDirections] = useState<number | null>(null);
 
-  // 1) DBの sessions.directions を取得
+  // 1) DBの sessions2.directions を取得
   useEffect(() => {
     if (!session_id) return;
     const fetchSessionDirections = async () => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from('sessions2')
         .select('directions')
         .eq('id', session_id)
         .single();
       if (error || !data) {
-        console.error('Failed to fetch sessions.directions', error);
+        console.error('Failed to fetch sessions2.directions', error);
         return;
       }
       setSessionDirections(data.directions);

--- a/src/pages/mobile/phasesA/index.tsx
+++ b/src/pages/mobile/phasesA/index.tsx
@@ -31,7 +31,7 @@ export default function PhasesPage() {
 
     const fetchSessionUsers = async () => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from('sessions2')
         .select('user_a, user_b')
         .eq('id', session_id)
         .single();

--- a/src/pages/mobile/phasesB/dialog.tsx
+++ b/src/pages/mobile/phasesB/dialog.tsx
@@ -10,17 +10,17 @@ export default function DialogPage() {
 
   const [sessionDirections, setSessionDirections] = useState<number | null>(null);
 
-  // 1) DBの sessions.directions を取得
+  // 1) DBの sessions2.directions を取得
   useEffect(() => {
     if (!session_id) return;
     const fetchSessionDirections = async () => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from('sessions2')
         .select('directions')
         .eq('id', session_id)
         .single();
       if (error || !data) {
-        console.error('Failed to fetch sessions.directions', error);
+        console.error('Failed to fetch sessions2.directions', error);
         return;
       }
       setSessionDirections(data.directions);

--- a/src/pages/mobile/phasesB/index.tsx
+++ b/src/pages/mobile/phasesB/index.tsx
@@ -30,7 +30,7 @@ export default function PhasesPage() {
 
     const fetchSessionUsers = async () => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from('sessions2')
         .select('user_a')
         .eq('id', session_id)
         .single();

--- a/src/pages/mobile/sessionsA/new.tsx
+++ b/src/pages/mobile/sessionsA/new.tsx
@@ -1,4 +1,4 @@
-// pages/sessions/new.tsx
+// pages/sessions2/new.tsx
 
 import React, { useEffect, useState } from 'react';
 import { supabase } from '@/utils/supabaseClient';
@@ -13,8 +13,8 @@ type UserData = {
 export default function NewSessionPage() {
   const router = useRouter();
   const [users, setUsers] = useState<UserData[]>([]);
-  const [userA, setUserA] = useState('');       // sessions.user_a
-  const [userB, setUserB] = useState('');       // sessions.user_b
+  const [userA, setUserA] = useState('');       // sessions2.user_a
+  const [userB, setUserB] = useState('');       // sessions2.user_b
   const [directions, setDirections] = useState<number>(1); // 1=自分先, 0=相手先
 
   useEffect(() => {
@@ -33,9 +33,9 @@ export default function NewSessionPage() {
 
   const handleCreateSession = async () => {
     try {
-      // 1) sessionsに INSERT
-      const { data: sessionsData, error: sessionsError } = await supabase
-        .from('sessions')
+      // 1) sessions2に INSERT
+      const { data: sessions2Data, error: sessions2Error } = await supabase
+        .from('sessions2')
         .insert([
           {
             user_a: userA,
@@ -45,16 +45,16 @@ export default function NewSessionPage() {
         ])
         .select(); // returning
 
-      if (sessionsError) {
-        console.error('Error inserting into sessions:', sessionsError);
+      if (sessions2Error) {
+        console.error('Error inserting into sessions2:', sessions2Error);
         alert('セッション作成に失敗しました');
         return;
       }
-      if (!sessionsData || sessionsData.length === 0) {
+      if (!sessions2Data || sessions2Data.length === 0) {
         alert('セッション作成に失敗しました(データなし)');
         return;
       }
-      const newSession = sessionsData[0];
+      const newSession = sessions2Data[0];
       console.log('Created session:', newSession);
 
       // 2) phasesに INSERT (session_id & directions=1)

--- a/src/pages/mobile/sessionsB/new.tsx
+++ b/src/pages/mobile/sessionsB/new.tsx
@@ -1,4 +1,4 @@
-// pages/sessions/new.tsx
+// pages/sessions2/new.tsx
 
 import React, { useEffect, useState } from 'react';
 import { supabase } from '@/utils/supabaseClient';
@@ -13,8 +13,8 @@ type UserData = {
 export default function NewSessionPage() {
   const router = useRouter();
   const [users, setUsers] = useState<UserData[]>([]);
-  const [userA, setUserA] = useState('');       // sessions.user_a
-  const [userB, setUserB] = useState('');       // sessions.user_b
+  const [userA, setUserA] = useState('');       // sessions2.user_a
+  const [userB, setUserB] = useState('');       // sessions2.user_b
   const [directions, setDirections] = useState<number>(1); // 1=自分先, 0=相手先
 
   useEffect(() => {
@@ -33,9 +33,9 @@ export default function NewSessionPage() {
 
   const handleCreateSession = async () => {
     try {
-      // 1) sessionsに INSERT
-      const { data: sessionsData, error: sessionsError } = await supabase
-        .from('sessions')
+      // 1) sessions2に INSERT
+      const { data: sessions2Data, error: sessions2Error } = await supabase
+        .from('sessions2')
         .insert([
           {
             user_a: userA,
@@ -45,16 +45,16 @@ export default function NewSessionPage() {
         ])
         .select(); // returning
 
-      if (sessionsError) {
-        console.error('Error inserting into sessions:', sessionsError);
+      if (sessions2Error) {
+        console.error('Error inserting into sessions2:', sessions2Error);
         alert('セッション作成に失敗しました');
         return;
       }
-      if (!sessionsData || sessionsData.length === 0) {
+      if (!sessions2Data || sessions2Data.length === 0) {
         alert('セッション作成に失敗しました(データなし)');
         return;
       }
-      const newSession = sessionsData[0];
+      const newSession = sessions2Data[0];
       console.log('Created session:', newSession);
 
       // 2) phasesに INSERT (session_id & directions=1)


### PR DESCRIPTION
# Summary
- DBを元々使っていた`tracks`, `sessions`, `phases`, `logs`から`track2`, `sessions2`, `phases2`, `logs2`に変更した
- `track2`について、trackのspotify_track_idをPrimary keyとするのではなく一意にidを定義し、PKとした
- spotfy_track_idとuser_idの組み合わせでユニークな値でDBにインサートされるように制約を実装した
